### PR TITLE
Make a smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM ubuntu:14.04.2
 MAINTAINER Rogier Slag
 
-# Make the machine up to date and install some dependencies
-RUN apt-get install -y software-properties-common python
-RUN add-apt-repository ppa:chris-lea/node.js
-RUN echo "deb http://us.archive.ubuntu.com/ubuntu/ precise universe" >> /etc/apt/sources.list
-RUN apt-get update && apt-get upgrade -y && apt-get install build-essential make gcc nodejs -y
+# In order to reduce the image size, we need to do all of this in one command
+RUN apt-get update && \
+  apt-get install -y software-properties-common && \
+  add-apt-repository ppa:chris-lea/node.js && \
+  apt-get remove -y software-properties-common && \
+  apt-get autoremove -y && \
+  apt-get clean
+# get node.js
+RUN apt-get update && apt-get install -y nodejs && apt-get clean
 
 # Set the application
 ADD package.json /opt/consuela/package.json


### PR DESCRIPTION
By combining stuff we prevent that docker creates cache images for the useless apt-get updates etc.
