### PR TITLE
Protect merge locks with a secret key

### DIFF
--- a/config/default.json.example
+++ b/config/default.json.example
@@ -14,6 +14,7 @@
   "repos":
     [
       "rogierslag/consuela"
-    ]
+    ],
+    "lockKey": "secret"
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,11 +1,11 @@
 import checkHealth from './health';
 import testPayload from './test-payload';
 import labelCheck, {checkPullRequestBody} from './label-check';
-import {validateRepo, putMergeLock, releaseMergeLock} from './merge-lock';
+import {validateSecretKey, validateRepo, putMergeLock, releaseMergeLock} from './merge-lock';
 
 export default function setupRoutes(app) {
 	app.get('/health', checkHealth);
 	app.post('/', testPayload, checkPullRequestBody, labelCheck);
-	app.post('/merge-lock', validateRepo, putMergeLock);
-	app.delete('/merge-lock', validateRepo, releaseMergeLock);
+	app.post('/merge-lock', validateSecretKey, validateRepo, putMergeLock);
+	app.delete('/merge-lock', validateSecretKey, validateRepo, releaseMergeLock);
 }

--- a/src/routes/merge-lock.js
+++ b/src/routes/merge-lock.js
@@ -17,6 +17,24 @@ export function validateRepo(req, res, next) {
 	}
 }
 
+export function validateSecretKey(req, res, next) {
+	const secretKey = config.get('lockKey');
+	if(!secretKey) {
+		log.warn(`No secret key defined. For a public service this is not very safe!`);
+		next();
+		return;
+	}
+
+	const suppliedKey = req.query.secret;
+	if(secretKey === suppliedKey) {
+		next();
+		return;
+	}
+
+	log.warn(`Incorrect secret key supplied`);
+	res.sendStatus(401);
+}
+
 export async function putMergeLock(req, res) {
 	const repo = req.query.repo;
 	const message = req.query.message ? `: ${decodeURIComponent(req.query.message)}` : '';


### PR DESCRIPTION
Ensure one can protect these end pints to prevent a rogue external user settingthese locks without adequate permission.

By adding a secret pre-shared key, it is no longer possible to just guess a password
